### PR TITLE
GotOpt Parse

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,27 +1,34 @@
 package gotopt
 
 import (
+	"errors"
 	"fmt"
 )
 
 // ErrRequiredArg is the error for when a required argument is missing.
 type ErrRequiredArg struct {
-	OptOpt int
+	Opt int
 }
 
 func (e *ErrRequiredArg) Error() string {
-	return fmt.Sprintf("arg required for opt '%c'", e.OptOpt)
+	return fmt.Sprintf("arg required for opt '%c'", e.Opt)
 }
 
 // ErrUnknownOpt is the error for when an unknown option is encountered.
 type ErrUnknownOpt struct {
-	OptOpt int
-	OptArg string
+	Opt      int
+	LongName string
 }
 
 func (e *ErrUnknownOpt) Error() string {
-	if OptArg == "" {
-		return fmt.Sprintf("unknown option '%c'", e.OptOpt)
+	if e.LongName == "" {
+		return fmt.Sprintf("unknown option '-%c'", e.Opt)
 	}
-	return fmt.Sprintf("unknown option '%s'", e.OptArg)
+	return fmt.Sprintf("unknown option '--%s'", e.LongName)
 }
+
+var (
+	// ErrEmptyArgList is returned by Parser.Parse and Parser.ParseAll when
+	// there is an empty argument list.
+	ErrEmptyArgList = errors.New("empty arg list")
+)

--- a/getopt_long.go
+++ b/getopt_long.go
@@ -40,23 +40,26 @@ type longOptList struct {
 	next *longOptList
 }
 
-// GetOptLong TODO
+// GetOptLong behaves identically to GetOpt except long options beginning with
+// two dashes '--' are also accepted.
 func GetOptLong(
 	argv []string, optString string,
 	longOpts []*LongOption, longInd *int) int {
 
-	return parser.GetOptLong(argv, optString, longOpts, longInd)
+	return getOptParser.GetOptLong(argv, optString, longOpts, longInd)
 }
 
-// GetOptLongOnly TODO
+// GetOptLongOnly behavs identically to GetOptLong except that only long
+// options are accepted.
 func GetOptLongOnly(
-	argv []string, optString string,
-	longOpts []*LongOption, longInd *int) int {
+	argv []string, longOpts []*LongOption, longInd *int) int {
 
-	return parser.GetOptLongOnly(argv, optString, longOpts, longInd)
+	return getOptParser.GetOptLongOnly(argv, longOpts, longInd)
 }
 
-// GetOptLong TODO
+// GetOptLong behaves identically to the global GetOptLong function except all
+// reads and writes from and to the fields OptArg, OptInd, OptErr, OptOpt are
+// instance operations.
 func (p *GetOptParser) GetOptLong(
 	argv []string, optString string,
 	longOpts []*LongOption, longInd *int) int {
@@ -64,10 +67,11 @@ func (p *GetOptParser) GetOptLong(
 	return p.getOptInternal(argv, optString, longOpts, longInd, false, false)
 }
 
-// GetOptLongOnly TODO
+// GetOptLongOnly behaves identically to the global GetOptLongOnly function
+// except all reads and writes from and to the fields OptArg, OptInd, OptErr,
+// OptOpt are instance operations.
 func (p *GetOptParser) GetOptLongOnly(
-	argv []string, optString string,
-	longOpts []*LongOption, longInd *int) int {
+	argv []string, longOpts []*LongOption, longInd *int) int {
 
-	return p.getOptInternal(argv, optString, longOpts, longInd, true, false)
+	return p.getOptInternal(argv, "", longOpts, longInd, true, false)
 }

--- a/getopt_long_test.go
+++ b/getopt_long_test.go
@@ -98,9 +98,9 @@ func TestGetOptLongMissingName(t *testing.T) {
 	assertLongNoName(t, testGetOptLongGlobal(t, "tgnn07", "--time", "37", "-n"))
 	assertLongNoName(t, testGetOptLongGlobal(t, "tgnn08", "-n", "--time", "37"))
 
-	assertLongNoName(t, testGetOptLongGlobal(t, "tgok09", "--ti", "37", "-n"))
-	assertLongNoName(t, testGetOptLongGlobal(t, "tgok10", "-n", "--tim", "37"))
-	assertLongNoName(t, testGetOptLongGlobal(t, "tgok11", "--t", "37", "-n"))
+	assertLongNoName(t, testGetOptLongGlobal(t, "tgnn09", "--ti", "37", "-n"))
+	assertLongNoName(t, testGetOptLongGlobal(t, "tgnn10", "-n", "--tim", "37"))
+	assertLongNoName(t, testGetOptLongGlobal(t, "tgnn11", "--t", "37", "-n"))
 
 	assertLongNoName(t, testGetOptLongInstance(t, "tinn01", "--time=37", "-n"))
 	assertLongNoName(t, testGetOptLongInstance(t, "tinn02", "-n", "--time=37"))
@@ -112,9 +112,9 @@ func TestGetOptLongMissingName(t *testing.T) {
 	assertLongNoName(t, testGetOptLongInstance(t, "tinn07", "--time", "37", "-n"))
 	assertLongNoName(t, testGetOptLongInstance(t, "tinn08", "-n", "--time", "37"))
 
-	assertLongNoName(t, testGetOptLongInstance(t, "tgok09", "--ti", "37", "-n"))
-	assertLongNoName(t, testGetOptLongInstance(t, "tgok10", "-n", "--tim", "37"))
-	assertLongNoName(t, testGetOptLongInstance(t, "tgok11", "--t", "37", "-n"))
+	assertLongNoName(t, testGetOptLongInstance(t, "tgnn09", "--ti", "37", "-n"))
+	assertLongNoName(t, testGetOptLongInstance(t, "tgnn10", "-n", "--tim", "37"))
+	assertLongNoName(t, testGetOptLongInstance(t, "tgnn11", "--t", "37", "-n"))
 }
 
 func TestGetOptLongMissingNameW(t *testing.T) {
@@ -152,7 +152,7 @@ func TestGetOptLongNoTime(t *testing.T) {
 		assert.False(t, r.tfnd)
 		assert.IsType(t, &ErrRequiredArg{}, r.err)
 		err := r.err.(*ErrRequiredArg)
-		assert.EqualValues(t, 't', err.OptOpt)
+		assert.EqualValues(t, 't', err.Opt)
 		assert.NotEqual(t, "37", r.nsecs)
 		assert.False(t, r.nfnd)
 		assert.Equal(t, "", r.name)
@@ -171,7 +171,7 @@ func TestGetOptLongNoTime(t *testing.T) {
 		assert.False(t, r.tfnd)
 		assert.IsType(t, &ErrRequiredArg{}, r.err)
 		err := r.err.(*ErrRequiredArg)
-		assert.EqualValues(t, 't', err.OptOpt)
+		assert.EqualValues(t, 't', err.Opt)
 		assert.NotEqual(t, "37", r.nsecs)
 		assert.True(t, r.nfnd)
 		assert.Equal(t, "", r.name)
@@ -193,10 +193,10 @@ func TestGetOptLongUnknownOpt(t *testing.T) {
 		assert.Equal(t, "37", r.nsecs)
 		assert.IsType(t, &ErrUnknownOpt{}, r.err)
 		err := r.err.(*ErrUnknownOpt)
-		if err.OptArg == "" {
-			assert.EqualValues(t, u, fmt.Sprintf("%c", err.OptOpt))
+		if err.LongName == "" {
+			assert.EqualValues(t, u, fmt.Sprintf("%c", err.Opt))
 		} else {
-			assert.EqualValues(t, u, err.OptArg)
+			assert.EqualValues(t, u, err.LongName)
 		}
 		assert.False(t, r.nfnd)
 		assert.Equal(t, "", r.name)
@@ -228,10 +228,10 @@ func TestGetOptLongUnknownOpt(t *testing.T) {
 		assert.Equal(t, "", r.name)
 		assert.IsType(t, &ErrUnknownOpt{}, r.err)
 		err := r.err.(*ErrUnknownOpt)
-		if err.OptArg == "" {
-			assert.EqualValues(t, u, fmt.Sprintf("%c", err.OptOpt))
+		if err.LongName == "" {
+			assert.EqualValues(t, u, fmt.Sprintf("%c", err.Opt))
 		} else {
-			assert.EqualValues(t, u, err.OptArg)
+			assert.EqualValues(t, u, err.LongName)
 		}
 	}
 	a2(t, testGetOptLongGlobal(t, "tgunkn05", "--t=37", "-n", "effie", "-f"), "f")
@@ -249,8 +249,8 @@ func TestGetOptLongUnknownOpt(t *testing.T) {
 		assert.Equal(t, "37", r.nsecs)
 		assert.IsType(t, &ErrUnknownOpt{}, r.err)
 		err := r.err.(*ErrUnknownOpt)
-		assert.EqualValues(t, 0, err.OptOpt)
-		assert.EqualValues(t, "hello", r.optArg)
+		assert.EqualValues(t, 0, err.Opt)
+		assert.EqualValues(t, "hello", err.LongName)
 		assert.False(t, r.nfnd)
 		assert.Equal(t, "", r.name)
 	}
@@ -338,7 +338,7 @@ func testGetOptLongGlobal(t *testing.T, argv ...string) *getOptLongTestResult {
 			return r
 		default: // ?
 			r.optArg = OptArg
-			r.err = &ErrUnknownOpt{OptOpt, ""}
+			r.err = &ErrUnknownOpt{OptOpt, OptArg}
 			return r
 		}
 	}
@@ -409,7 +409,7 @@ func testGetOptLongInstance(t *testing.T, argv ...string) *getOptLongTestResult 
 			return r
 		default: // ?
 			r.optArg = p.OptArg
-			r.err = &ErrUnknownOpt{p.OptOpt, ""}
+			r.err = &ErrUnknownOpt{p.OptOpt, p.OptArg}
 			return r
 		}
 	}

--- a/getopt_test.go
+++ b/getopt_test.go
@@ -1,10 +1,36 @@
 package gotopt
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestGetOptLoop(t *testing.T) {
+	f := func() {
+		OptInd = 1
+	}
+	f()
+	defer f()
+
+	argv := []string{"ProgramName", "-nt37", "effie"}
+	for {
+		opt := GetOpt(argv, ":nt:")
+		if opt == -1 {
+			break
+		}
+		switch opt {
+		case 'n':
+			fmt.Println("-n detected")
+		case 't':
+			fmt.Printf("-t detected, arg=%s\n", OptArg)
+		}
+	}
+	if OptInd < len(argv) {
+		fmt.Printf("name is %s\n", argv[OptInd])
+	}
+}
 
 func TestGetOptOk(t *testing.T) {
 	assertOk(t, testGetOptGlobal(t, "tgok01", "-t", "37", "-n", "effie"))
@@ -24,10 +50,10 @@ func TestGetOptOk(t *testing.T) {
 	assertOk(t, testGetOptInstance(t, "tiok04", "effie", "-nt", "37"))
 	assertOk(t, testGetOptInstance(t, "tiok05", "effie", "-n", "-t", "37"))
 
-	assertOk(t, testGetOptGlobal(t, "tiok06", "-t37", "-n", "effie"))
-	assertOk(t, testGetOptGlobal(t, "tiok07", "-nt37", "effie"))
-	assertOk(t, testGetOptGlobal(t, "tiok08", "-t37", "effie", "-n"))
-	assertOk(t, testGetOptGlobal(t, "tiok09", "effie", "-nt37"))
+	assertOk(t, testGetOptInstance(t, "tiok06", "-t37", "-n", "effie"))
+	assertOk(t, testGetOptInstance(t, "tiok07", "-nt37", "effie"))
+	assertOk(t, testGetOptInstance(t, "tiok08", "-t37", "effie", "-n"))
+	assertOk(t, testGetOptInstance(t, "tiok09", "effie", "-nt37"))
 }
 
 func TestGetOptMissingName(t *testing.T) {
@@ -50,7 +76,7 @@ func TestGetOptNoTime(t *testing.T) {
 		assert.False(t, r.tfnd)
 		assert.IsType(t, &ErrRequiredArg{}, r.err)
 		err := r.err.(*ErrRequiredArg)
-		assert.EqualValues(t, 't', err.OptOpt)
+		assert.EqualValues(t, 't', err.Opt)
 		assert.NotEqual(t, "37", r.nsecs)
 		assert.False(t, r.nfnd)
 		assert.Equal(t, "", r.name)
@@ -61,7 +87,7 @@ func TestGetOptNoTime(t *testing.T) {
 		assert.False(t, r.tfnd)
 		assert.IsType(t, &ErrRequiredArg{}, r.err)
 		err := r.err.(*ErrRequiredArg)
-		assert.EqualValues(t, 't', err.OptOpt)
+		assert.EqualValues(t, 't', err.Opt)
 		assert.NotEqual(t, "37", r.nsecs)
 		assert.True(t, r.nfnd)
 		assert.Equal(t, "", r.name)
@@ -72,7 +98,7 @@ func TestGetOptNoTime(t *testing.T) {
 		assert.False(t, r.tfnd)
 		assert.IsType(t, &ErrRequiredArg{}, r.err)
 		err := r.err.(*ErrRequiredArg)
-		assert.EqualValues(t, 't', err.OptOpt)
+		assert.EqualValues(t, 't', err.Opt)
 		assert.NotEqual(t, "37", r.nsecs)
 		assert.False(t, r.nfnd)
 		assert.Equal(t, "", r.name)
@@ -83,7 +109,7 @@ func TestGetOptNoTime(t *testing.T) {
 		assert.False(t, r.tfnd)
 		assert.IsType(t, &ErrRequiredArg{}, r.err)
 		err := r.err.(*ErrRequiredArg)
-		assert.EqualValues(t, 't', err.OptOpt)
+		assert.EqualValues(t, 't', err.Opt)
 		assert.NotEqual(t, "37", r.nsecs)
 		assert.True(t, r.nfnd)
 		assert.Equal(t, "", r.name)
@@ -97,7 +123,7 @@ func TestGetOptUnknownOpt(t *testing.T) {
 		assert.Equal(t, "37", r.nsecs)
 		assert.IsType(t, &ErrUnknownOpt{}, r.err)
 		err := r.err.(*ErrUnknownOpt)
-		assert.EqualValues(t, 'f', err.OptOpt)
+		assert.EqualValues(t, 'f', err.Opt)
 		assert.False(t, r.nfnd)
 		assert.Equal(t, "", r.name)
 	}
@@ -110,7 +136,7 @@ func TestGetOptUnknownOpt(t *testing.T) {
 		assert.Equal(t, "", r.name)
 		assert.IsType(t, &ErrUnknownOpt{}, r.err)
 		err := r.err.(*ErrUnknownOpt)
-		assert.EqualValues(t, 'f', err.OptOpt)
+		assert.EqualValues(t, 'f', err.Opt)
 	}
 
 	{
@@ -119,7 +145,7 @@ func TestGetOptUnknownOpt(t *testing.T) {
 		assert.Equal(t, "37", r.nsecs)
 		assert.IsType(t, &ErrUnknownOpt{}, r.err)
 		err := r.err.(*ErrUnknownOpt)
-		assert.EqualValues(t, 'f', err.OptOpt)
+		assert.EqualValues(t, 'f', err.Opt)
 		assert.False(t, r.nfnd)
 		assert.Equal(t, "", r.name)
 	}
@@ -132,7 +158,7 @@ func TestGetOptUnknownOpt(t *testing.T) {
 		assert.Equal(t, "", r.name)
 		assert.IsType(t, &ErrUnknownOpt{}, r.err)
 		err := r.err.(*ErrUnknownOpt)
-		assert.EqualValues(t, 'f', err.OptOpt)
+		assert.EqualValues(t, 'f', err.Opt)
 	}
 }
 

--- a/gotopt.go
+++ b/gotopt.go
@@ -1,0 +1,459 @@
+package gotopt
+
+import (
+	"bytes"
+	"fmt"
+)
+
+// Parser can be used to parse multiple argument slices.
+type Parser interface {
+	// Parse immediately returns a channel on which ParserState instances are
+	// receives as they are parsed from the supplied arguments.
+	Parse(argv []string) (<-chan ParserState, error)
+
+	// ParseAll parses all arguments and then returns the final ParserState.
+	ParseAll(argv []string) (ParserState, error)
+
+	// Opt registers an option with the parser.
+	Opt(opt int, longName string, optType OptionTypes)
+}
+
+// ParserState is the current state of the parser.
+//
+// A ParserState is a node in a double-linked list, with each node having a
+// pointer to the first and last elements in the list as well as the previous
+// and next ParseState instances as well.
+//
+// If a ParserState object is received on the channel returned from the Parse
+// operation, the ParserState's references to the first, last, previous, and
+// next nodes in the list may not yet be established. The list to which a
+// ParserState belongs cannot be safely traversed until the entire Parse
+// operation completes. Any attempts to do so should be considered unreliable
+// and unsupported.
+//
+// The ParseAll operation does not return until all ParserStates are discovered,
+// thus it's safe to immediately begin traversing the list of ParserStates using
+// the navigation methods as soon as the ParseAll operation completes.
+type ParserState interface {
+	// Value returns the result of the interation of the GetOpt loop that this
+	// ParserState represents. The value can be an Option, an error, or if
+	// there are non-option arguments remaining during the final iteration of
+	// the GetOpt loop, an array of strings ([]string).
+	Value() interface{}
+
+	// Index returns the index of the ParserState with respect to the total
+	// number of ParserState instances created as a result of a Parse or
+	// ParseAll operation. If five instances are created, the first ParserState
+	// would have an index of 0, the second, 1, the third, 2, the fourth 3, and
+	// the fifth, 4.
+	Index() int
+
+	// First returns the first ParserState created as a result of a Parse or
+	// ParseAll operation.
+	First() ParserState
+
+	// Prev returns a flag indicating whether or not there is a previous node
+	// and a reference to that node.
+	Prev() (ParserState, bool)
+
+	// Next returns a flag indicating whether or not there is a next node
+	// and a reference to that node.
+	Next() (ParserState, bool)
+
+	// Last returns the last ParserState created as a result of a Parse or
+	// ParseAll operation.
+	Last() ParserState
+
+	// LookupOpt looks up all the options that match the given option character.
+	LookupOpt(opt int) []ParserState
+
+	// LookupOptLong looks up all the options that match the given option name.
+	LookupOptLong(opt string) []ParserState
+}
+
+// Option is the representation of an option as sent to clients receiving the
+// results of a Parse or ParseAll operation.
+//
+// The value returned by the Index() function is not necessarily the same value
+// as as the values returned by the corresponding ParserState index. For
+// example:
+//
+//     -n --time 37 -n
+//
+// In the above argument list there are three options:
+//
+//   -n
+//   --time
+//   -n
+//
+// Those options will generate three ParserState instances with indices of
+// 0, 1, 2.
+//
+// Those same options will also generate three Option instances, one
+// for each ParserState. Those Option instances will also have Index values
+// set, but those will be 0, 0, 1.
+type Option interface {
+	// Opt returns the option character if one was provided; otherwise this
+	// function returns zero.
+	Opt() int
+
+	// LongName returns the option's long name if one was provided; otherwise
+	// this function returns an empty string.
+	LongName() string
+
+	// Type returns a value indicating whether or not the option required an
+	// argument, took an optional argument, or was simply a flag.
+	Type() OptionTypes
+
+	// Value returns the option's argument if one was parsed.
+	Value() string
+
+	// Index returns the index of the Option with respect to the total
+	// number of Option instances created with the same Opt or LongName
+	// values as a result of a Parse or ParseAll operation. If five instances
+	// are created, the first ParserState would have an index of 0, the second,
+	// 1, the third, 2, the fourth 3, and the fifth, 4.
+	Index() int
+}
+
+// optDef is the definition of an option as recorded when registering options.
+type optDef struct {
+	opt      int
+	longName string
+	optType  OptionTypes
+}
+
+// parsedOpt is an option that's been parsed.
+type parsedOpt struct {
+	optDef
+	value string
+	index int
+}
+
+func (o *parsedOpt) Opt() int {
+	return o.opt
+}
+func (o *parsedOpt) LongName() string {
+	return o.longName
+}
+func (o *parsedOpt) Type() OptionTypes {
+	return o.optType
+}
+func (o *parsedOpt) Value() string {
+	return o.value
+}
+func (o *parsedOpt) Index() int {
+	return o.index
+}
+func (o *parsedOpt) String() string {
+	b := &bytes.Buffer{}
+	b.WriteString("&{")
+	fmt.Fprintf(b, "Opt:%[1]d|%[1]c", o.opt)
+	fmt.Fprintf(b, " LongName:%s", o.longName)
+	fmt.Fprintf(b, " Index:%d", o.index)
+	fmt.Fprintf(b, " Type:%+v", o.optType)
+	fmt.Fprintf(b, " Value:%s", o.value)
+	b.WriteString("}")
+	return b.String()
+}
+
+// the backing struct for the ParserState interface
+type parserState struct {
+	value interface{}
+	index int
+	first *parserState
+	prev  *parserState
+	next  *parserState
+	last  *parserState
+}
+
+func (p *parserState) Value() interface{} {
+	return p.value
+}
+func (p *parserState) Index() int {
+	return p.index
+}
+func (p *parserState) First() ParserState {
+	return p.first
+}
+func (p *parserState) Prev() (ParserState, bool) {
+	if p.prev == nil {
+		return nil, false
+	}
+	return p.prev, true
+}
+func (p *parserState) Next() (ParserState, bool) {
+	if p.next == nil {
+		return nil, false
+	}
+	return p.next, true
+}
+func (p *parserState) Last() ParserState {
+	return p.last
+}
+
+func (p *parserState) LookupOpt(opt int) []ParserState {
+	v := []ParserState{}
+	c := p.first
+	for {
+		if c == nil {
+			debugln("c == nil")
+			break
+		}
+		switch i := c.value.(type) {
+		case Option:
+			debugf("opt=%c found", opt)
+			if i.Opt() == opt {
+				v = append(v, c)
+			}
+		}
+		c = c.next
+	}
+	return v
+}
+
+func (p *parserState) LookupOptLong(opt string) []ParserState {
+	v := []ParserState{}
+	c := p.first
+	for {
+		if c == nil {
+			break
+		}
+		switch i := c.value.(type) {
+		case Option:
+			if i.LongName() == opt {
+				v = append(v, c)
+			}
+		}
+		c = p.next
+	}
+	return v
+}
+
+// parser is the backing struct for the Parser interface.
+type parser struct {
+	parsed    bool
+	opts      map[*optDef]*optDef
+	shortOpts map[int]*optDef
+	longOpts  map[string]*optDef
+}
+
+// NewParser returns a new parser.
+func NewParser() Parser {
+	return &parser{
+		opts:      map[*optDef]*optDef{},
+		shortOpts: map[int]*optDef{},
+		longOpts:  map[string]*optDef{},
+	}
+}
+
+// Parse parses the supplied arguments.
+func (p *parser) Parse(argv []string) (<-chan ParserState, error) {
+	if len(argv) == 0 {
+		return nil, ErrEmptyArgList
+	}
+	c := make(chan ParserState)
+	go func() {
+		p.parse(argv, c)
+		close(c)
+	}()
+	return c, nil
+}
+
+// ParseAll parses the supplied arguments and returns the final ParserState.
+func (p *parser) ParseAll(argv []string) (ParserState, error) {
+	c, err := p.Parse(argv)
+	if err != nil {
+		return nil, err
+	}
+	var ps ParserState
+	for ps = range c {
+		// do nothing
+	}
+	return ps, nil
+}
+
+func (p *parser) parse(argv []string, c chan<- ParserState) {
+
+	b := &bytes.Buffer{}
+	longOpts := []*LongOption{}
+	b.WriteString(":W;")
+
+	for _, o := range p.opts {
+		debugf("opt.Opt=%[1]d|%[1]c, opt.LongName=%s", o.opt, o.longName)
+
+		if o.opt > 0 {
+			b.WriteByte(byte(o.opt))
+			if o.optType == RequiredArgument || o.optType == OptionalArgument {
+				b.WriteByte(':')
+				if o.optType == OptionalArgument {
+					b.WriteByte(':')
+				}
+			}
+		}
+		if o.longName != "" {
+			lo := &LongOption{Name: o.longName, Type: o.optType}
+			if o.opt > 0 {
+				lo.Val = o.opt
+				lo.Flag = nil
+			}
+			longOpts = append(longOpts, lo)
+		}
+	}
+
+	longInd := 0
+	optString := b.String()
+	gop := NewGetOptParser()
+	var pf func() int
+	if len(longOpts) > 0 {
+		pf = func() int {
+			return gop.GetOptLong(argv, optString, longOpts, &longInd)
+		}
+	} else {
+		pf = func() int {
+			return gop.GetOpt(argv, optString)
+		}
+	}
+
+	var (
+		psPrev *parserState
+		psInd  int
+	)
+
+	optIndices := map[*optDef]int{}
+
+	for {
+		opt := pf()
+		if opt == -1 {
+			break
+		}
+
+		debugf(
+			"opt=%[1]d|%[1]c, OptOpt=%[2]d|%[2]c, OptArg=%s",
+			opt, gop.OptOpt, gop.OptArg)
+
+		var psCurr *parserState
+
+		switch opt {
+		case 0:
+			if longInd > -1 && longInd < len(longOpts) {
+				if o, ok := p.longOpts[longOpts[longInd].Name]; ok {
+					optIdx, optIdxOk := optIndices[o]
+					if optIdxOk {
+						optIdx++
+					} else {
+						optIdx = 0
+					}
+					optIndices[o] = optIdx
+					psCurr = &parserState{
+						value: &parsedOpt{
+							optDef: optDef{
+								opt:      o.opt,
+								longName: o.longName,
+							},
+							value: gop.OptArg,
+							index: optIdx,
+						},
+					}
+				}
+			}
+		case ':':
+			psCurr = &parserState{
+				value: &ErrRequiredArg{gop.OptOpt},
+			}
+		case '?':
+			psCurr = &parserState{
+				value: &ErrUnknownOpt{gop.OptOpt, gop.OptArg},
+			}
+		case 'W':
+			psCurr = &parserState{
+				value: &ErrUnknownOpt{gop.OptOpt, gop.OptArg},
+			}
+		default:
+			if o, ok := p.shortOpts[opt]; ok {
+				optIdx, optIdxOk := optIndices[o]
+				if optIdxOk {
+					optIdx++
+				} else {
+					optIdx = 0
+				}
+				optIndices[o] = optIdx
+				psCurr = &parserState{
+					value: &parsedOpt{
+						optDef: optDef{
+							opt:      o.opt,
+							longName: o.longName,
+						},
+						value: gop.OptArg,
+						index: optIdx,
+					},
+				}
+			} else {
+				psCurr = &parserState{
+					value: &ErrUnknownOpt{gop.OptOpt, gop.OptArg},
+				}
+			}
+		}
+
+		if psCurr != nil {
+			psCurr.index = psInd
+			psCurr.next = nil
+			psInd++
+			if psPrev == nil {
+				psCurr.first = psCurr
+			} else {
+				psCurr.prev = psPrev
+				psPrev.next = psCurr
+				psCurr.first = psPrev.first
+			}
+			psPrev = psCurr
+			c <- psCurr
+		}
+	}
+
+	if gop.OptInd < len(argv) {
+		psCurr := &parserState{
+			index: psInd,
+			value: argv[gop.OptInd:],
+		}
+		if psPrev == nil {
+			psCurr.first = psCurr
+		} else {
+			psCurr.prev = psPrev
+			psPrev.next = psCurr
+			psCurr.first = psPrev.first
+		}
+		psPrev = psCurr
+		c <- psCurr
+	}
+
+	if psPrev != nil {
+		psCurr := psPrev.first
+		for {
+			psCurr.last = psPrev
+			psCurr = psCurr.next
+			if psCurr == nil {
+				break
+			}
+		}
+	}
+}
+
+// Opt registers an option with the parser.
+func (p *parser) Opt(
+	opt int,
+	longName string,
+	optType OptionTypes) {
+
+	if opt <= 0 && longName == "" {
+		panic("opt and longName invalid")
+	}
+	o := &optDef{opt: opt, longName: longName, optType: optType}
+	if o.opt > 0 {
+		p.shortOpts[o.opt] = o
+	}
+	if o.longName != "" {
+		p.longOpts[o.longName] = o
+	}
+	p.opts[o] = o
+}

--- a/gotopt_test.go
+++ b/gotopt_test.go
@@ -1,0 +1,455 @@
+package gotopt
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGotOptParserParse(t *testing.T) {
+	p := NewParser()
+	p.Opt('n', "name", NoArgument)
+	p.Opt('t', "time", RequiredArgument)
+
+	c, _ := p.Parse([]string{"ProgramName", "-nt37", "effie"})
+
+	for ps := range c {
+		switch tv := ps.Value().(type) {
+		case Option:
+			fmt.Printf("-%c detected", tv.Opt())
+			if tv.Opt() == 't' {
+				fmt.Printf(", arg=%s", tv.Value())
+			}
+			fmt.Println()
+		case []string:
+			fmt.Printf("name is %s\n", tv[0])
+		}
+	}
+}
+
+func TestGotOptParserParseAll(t *testing.T) {
+	p := NewParser()
+	p.Opt('n', "name", NoArgument)
+	p.Opt('t', "time", RequiredArgument)
+
+	ps, _ := p.ParseAll([]string{"ProgramName", "-nt37", "effie"})
+	ps = ps.First()
+
+	for {
+		switch tv := ps.Value().(type) {
+		case Option:
+			fmt.Printf("-%c detected", tv.Opt())
+			if tv.Opt() == 't' {
+				fmt.Printf(", arg=%s", tv.Value())
+			}
+			fmt.Println()
+		case []string:
+			fmt.Printf("name is %s\n", tv[0])
+		}
+		var ok bool
+		if ps, ok = ps.Next(); !ok {
+			break
+		}
+	}
+}
+
+func TestParserOk(t *testing.T) {
+	assertParseOk(t, testParse(t, "tipok01", "--time=37", "-n", "effie"))
+	assertParseOk(t, testParse(t, "tipok02", "-n", "--time=37", "effie"))
+	assertParseOk(t, testParse(t, "tipok03", "--time=37", "effie", "-n"))
+	assertParseOk(t, testParse(t, "tipok04", "effie", "-n", "--time=37"))
+
+	assertParseOk(t, testParse(t, "tipok05", "--time", "37", "-n", "effie"))
+	assertParseOk(t, testParse(t, "tipok06", "-n", "--time", "37", "effie"))
+	assertParseOk(t, testParse(t, "tipok07", "--time", "37", "effie", "-n"))
+	assertParseOk(t, testParse(t, "tipok08", "effie", "-n", "--time", "37"))
+
+	assertParseOk(t, testParse(t, "tipok09", "--ti", "37", "-n", "effie"))
+	assertParseOk(t, testParse(t, "tipok10", "-n", "--tim", "37", "effie"))
+	assertParseOk(t, testParse(t, "tipok11", "--t", "37", "effie", "-n"))
+
+	assertParseOk(t, testParse(t, "tipok12", "--time", "37", "-n", "effie"))
+	assertParseOk(t, testParse(t, "tipok13", "--na", "--time", "37", "effie"))
+	assertParseOk(t, testParse(t, "tipok14", "--time", "37", "effie", "--nam"))
+	assertParseOk(t, testParse(t, "tipok15", "effie", "--name", "--time", "37"))
+}
+
+func TestParserOkW(t *testing.T) {
+	assertParseOk(t, testParse(t, "tipokw01", "-W", "time=37", "-n", "effie"))
+	assertParseOk(t, testParse(t, "tipokw02", "-n", "-W", "time=37", "effie"))
+	assertParseOk(t, testParse(t, "tipokw03", "-W", "time=37", "effie", "-n"))
+	assertParseOk(t, testParse(t, "tipokw04", "effie", "-n", "-W", "time=37"))
+
+	assertParseOk(t, testParse(t, "tipokw05", "-W", "time", "37", "-n", "effie"))
+	assertParseOk(t, testParse(t, "tipokw06", "-n", "-W", "time", "37", "effie"))
+	assertParseOk(t, testParse(t, "tipokw07", "-W", "time", "37", "effie", "-n"))
+	assertParseOk(t, testParse(t, "tipokw08", "effie", "-n", "-W", "time", "37"))
+
+	assertParseOk(t, testParse(t, "tipokw09", "-W", "ti", "37", "-n", "effie"))
+	assertParseOk(t, testParse(t, "tipokw10", "-n", "-W", "tim", "37", "effie"))
+	assertParseOk(t, testParse(t, "tipokw11", "-W", "t", "37", "effie", "-n"))
+
+	assertParseOk(t, testParse(t, "tipokw12", "-W", "time", "37", "-W", "n", "effie"))
+	assertParseOk(t, testParse(t, "tipokw13", "-W", "na", "-W", "time", "37", "effie"))
+	assertParseOk(t, testParse(t, "tipokw14", "-W", "time", "37", "effie", "-W", "nam"))
+	assertParseOk(t, testParse(t, "tipokw15", "effie", "-W", "name", "-W", "time", "37"))
+}
+
+func TestParserMissingName(t *testing.T) {
+	assertParseNoName(t, testParse(t, "tipnn01", "--time=37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnn02", "-n", "--time=37"))
+	assertParseNoName(t, testParse(t, "tipnn03", "--time=37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnn04", "-n", "--time=37"))
+
+	assertParseNoName(t, testParse(t, "tipnn05", "--time", "37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnn06", "-n", "--time", "37"))
+	assertParseNoName(t, testParse(t, "tipnn07", "--time", "37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnn08", "-n", "--time", "37"))
+
+	assertParseNoName(t, testParse(t, "tipnn09", "--ti", "37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnn10", "-n", "--tim", "37"))
+	assertParseNoName(t, testParse(t, "tipnn11", "--t", "37", "-n"))
+}
+
+func TestParserMissingNameW(t *testing.T) {
+	assertParseNoName(t, testParse(t, "tipnnw01", "-W", "time=37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnnw02", "-n", "-W", "time=37"))
+	assertParseNoName(t, testParse(t, "tipnnw03", "-W", "time=37", "-W", "n"))
+	assertParseNoName(t, testParse(t, "tipnnw04", "-W", "na", "-W", "time=37"))
+
+	assertParseNoName(t, testParse(t, "tipnnw05", "-W", "time", "37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnnw06", "-n", "-W", "time", "37"))
+	assertParseNoName(t, testParse(t, "tipnnw07", "-W", "time", "37", "-W", "n"))
+	assertParseNoName(t, testParse(t, "tipnnw08", "-W", "na", "-W", "time", "37"))
+
+	assertParseNoName(t, testParse(t, "tipnnw09", "-W", "ti", "37", "-n"))
+	assertParseNoName(t, testParse(t, "tipnnw10", "-W", "nam", "-W", "tim", "37"))
+	assertParseNoName(t, testParse(t, "tipnnw11", "-W", "t", "37", "-W", "name"))
+}
+
+func TestParserNoTime(t *testing.T) {
+	a1 := func(t *testing.T, r *parseTestResult) {
+		assert.False(t, r.tfnd)
+		assert.IsType(t, &ErrRequiredArg{}, r.err)
+		err := r.err.(*ErrRequiredArg)
+		assert.EqualValues(t, 't', err.Opt)
+		assert.NotEqual(t, "37", r.nsecs)
+		assert.False(t, r.nfnd)
+		assert.Equal(t, "", r.name)
+	}
+	a1(t, testParse(t, "tipnt01", "--t"))
+	a1(t, testParse(t, "tipnt02", "--ti"))
+	a1(t, testParse(t, "tipnt03", "--tim"))
+	a1(t, testParse(t, "tipnt04", "--time"))
+
+	a2 := func(t *testing.T, r *parseTestResult) {
+		assert.False(t, r.tfnd)
+		assert.IsType(t, &ErrRequiredArg{}, r.err)
+		err := r.err.(*ErrRequiredArg)
+		assert.EqualValues(t, 't', err.Opt)
+		assert.NotEqual(t, "37", r.nsecs)
+		assert.True(t, r.nfnd)
+		assert.Equal(t, "", r.name)
+	}
+	a2(t, testParse(t, "tipnt05", "-n", "--t"))
+	a2(t, testParse(t, "tipnt06", "-n", "--ti"))
+	a2(t, testParse(t, "tipnt07", "-n", "--tim"))
+	a2(t, testParse(t, "tipnt08", "-n", "--time"))
+}
+
+func TestParserUnknownOpt(t *testing.T) {
+	a1 := func(t *testing.T, r *parseTestResult, u string) {
+		assert.True(t, r.tfnd)
+		assert.Equal(t, "37", r.nsecs)
+		assert.IsType(t, &ErrUnknownOpt{}, r.err)
+		err := r.err.(*ErrUnknownOpt)
+		if err.LongName == "" {
+			assert.Equal(t, u, fmt.Sprintf("%c", err.Opt))
+		} else {
+			assert.Equal(t, u, err.LongName)
+		}
+		assert.False(t, r.nfnd)
+		assert.Equal(t, "", r.name)
+	}
+	a1(t, testParse(t, "tipunkn01a", "--t=37", "-f", "-n", "effie"), "f")
+	a1(t, testParse(t, "tipunkn02a", "--ti=37", "-fu", "-n", "effie"), "f")
+	a1(t, testParse(t, "tipunkn03a", "--tim=37", "-fub", "-n", "effie"), "f")
+	a1(t, testParse(t, "tipunkn04a", "--time=37", "-fubar", "-n", "effie"), "f")
+
+	a1(t, testParse(t, "tipunkn01b", "--t=37", "-W", "f", "-n", "effie"), "f")
+	a1(t, testParse(t, "tipunkn02b", "--ti=37", "-W", "fu", "-n", "effie"), "fu")
+	a1(t, testParse(t, "tipunkn03b", "--tim=37", "-W", "fub", "-n", "effie"), "fub")
+	a1(t, testParse(t, "tipunkn04b", "--time=37", "-W", "fubar", "-n", "effie"), "fubar")
+
+	a2 := func(t *testing.T, r *parseTestResult, u string) {
+		assert.True(t, r.tfnd)
+		assert.Equal(t, "37", r.nsecs)
+		assert.True(t, r.nfnd)
+		assert.Equal(t, "", r.name)
+		assert.IsType(t, &ErrUnknownOpt{}, r.err)
+		err := r.err.(*ErrUnknownOpt)
+		if err.LongName == "" {
+			assert.Equal(t, u, fmt.Sprintf("%c", err.Opt))
+		} else {
+			assert.Equal(t, u, err.LongName)
+		}
+	}
+	a2(t, testParse(t, "tipunkn05", "--t=37", "-n", "effie", "-f"), "f")
+	a2(t, testParse(t, "tipunkn06", "--ti=37", "-n", "effie", "-W", "f"), "f")
+	a2(t, testParse(t, "tipunkn07", "--tim=37", "-n", "effie", "-fu"), "f")
+	a2(t, testParse(t, "tipunkn08", "--time=37", "-n", "effie", "-W", "fubar"), "fubar")
+
+	a3 := func(t *testing.T, r *parseTestResult) {
+		assert.True(t, r.tfnd)
+		assert.Equal(t, "37", r.nsecs)
+		assert.IsType(t, &ErrUnknownOpt{}, r.err)
+		err := r.err.(*ErrUnknownOpt)
+		assert.Equal(t, 0, err.Opt)
+		assert.Equal(t, "hello", err.LongName)
+		assert.False(t, r.nfnd)
+		assert.Equal(t, "", r.name)
+	}
+	a3(t, testParse(t, "tipunkn09", "--t=37", "--hello", "-f", "-n", "effie"))
+	a3(t, testParse(t, "tipunkn10", "--ti=37", "--hello", "-f", "-n", "effie"))
+	a3(t, testParse(t, "tipunkn11", "--tim=37", "--hello", "-f", "-n", "effie"))
+	a3(t, testParse(t, "tipunkn12", "--time=37", "--hello", "-f", "-n", "effie"))
+}
+
+func TestParseOptional(t *testing.T) {
+
+	a1 := func(t *testing.T, r *parseTestResult) {
+		assert.True(t, r.tfnd)
+		assert.Equal(t, "37", r.nsecs)
+		assert.True(t, r.nfnd)
+		assert.Equal(t, "effie", r.name)
+		assert.True(t, r.xfnd)
+		assert.Equal(t, "play", r.xist)
+	}
+	a1(t, testParse(t, "tipopt01", "--time=37", "-n", "effie", "-xplay"))
+	a1(t, testParse(t, "tipopt02", "-n", "--time=37", "effie", "--xist=play"))
+	a1(t, testParse(t, "tipopt03", "--time=37", "effie", "-nxplay"))
+
+	// NOTE: This will fail due to getopt not parsing optional parameters for
+	// longOpts unless using an explicit equals sign. This StackOverflow
+	// post explains it - http://stackoverflow.com/questions/1052746
+	//
+	// a1(t, testParse(t, "tipopt04", "effie", "-n", "--time=37", "--xist", "play"))
+}
+
+func TestParseLongOnly(t *testing.T) {
+
+	a1 := func(t *testing.T, r *parseTestResult) {
+		assert.True(t, r.tfnd)
+		assert.Equal(t, "37", r.nsecs)
+		assert.True(t, r.nfnd)
+		assert.Equal(t, "effie", r.name)
+		assert.True(t, r.xfnd)
+		assert.Equal(t, "play", r.xist)
+		assert.True(t, r.pfnd)
+	}
+	a1(t, testParse(t, "tplo01", "--time=37", "-n", "effie", "-xplay", "--pulp"))
+	a1(t, testParse(t, "tplo02", "-n", "--time=37", "effie", "--xist=play", "--p"))
+	a1(t, testParse(t, "tplo03", "--time=37", "effie", "-nxplay", "--pu"))
+}
+
+func TestParserStateCount(t *testing.T) {
+	a1 := func(t *testing.T, ps ParserState, nct int) {
+		fps := ps.LookupOpt('n')
+		assert.Equal(t, nct, len(fps))
+		for _, i := range fps {
+			t.Logf("fpts=%+v", i)
+		}
+	}
+	a1(t, testParseAll(t, "tpct01", "--time=37", "-nn", "effie"), 2)
+	a1(t, testParseAll(t, "tpct02", "-n", "-nnn", "--time=37", "effie"), 4)
+	a1(t, testParseAll(t, "tpct03", "--name", "--time=37", "effie", "-nnn", "--name"), 5)
+	a1(t, testParseAll(t, "tpct04", "effie", "-nnn", "-nnnt", "37"), 6)
+}
+
+type testParserCountAndIndexData struct {
+	Argv    []string
+	Count   int
+	Indices []int
+}
+
+func TestParserCountAndIndex(t *testing.T) {
+
+	payloads := []*testParserCountAndIndexData{
+		&testParserCountAndIndexData{
+			Argv:    []string{"--time=37", "-nn", "effie"},
+			Count:   2,
+			Indices: []int{1, 2},
+		},
+		&testParserCountAndIndexData{
+			Argv:    []string{"-n", "-nnn", "--time=37", "effie"},
+			Count:   4,
+			Indices: []int{0, 1, 2, 3},
+		},
+		&testParserCountAndIndexData{
+			Argv:    []string{"--name", "--time=37", "effie", "-nnn", "--name"},
+			Count:   5,
+			Indices: []int{0, 2, 3, 4, 5},
+		},
+		&testParserCountAndIndexData{
+			Argv:    []string{"effie", "-nnn", "-nnnt", "37"},
+			Count:   6,
+			Indices: []int{0, 1, 2, 3, 4, 5},
+		},
+	}
+
+	testOpt := (*Option)(nil)
+	pp := 0
+
+	for x, td := range payloads {
+		assert.Equal(t, td.Count, len(td.Indices), "td.Count == len(td.Indices)")
+		argv := []string{fmt.Sprintf("tpctidx0%d", x)}
+		argv = append(argv, td.Argv...)
+		ps := testParseAll(t, argv...)
+		fps := ps.LookupOpt('n')
+		assert.Equal(t, td.Count, len(fps), "Count")
+		for y, fpsi := range fps {
+			assert.Implements(t, testOpt, fpsi.Value())
+			o := fpsi.Value().(Option)
+			assert.Equal(t, td.Indices[y], fpsi.Index(), "ParserState.Index")
+			assert.Equal(t, y, o.Index(), "Option.Index")
+		}
+		pp++
+	}
+
+	assert.Equal(t, 4, pp)
+}
+
+func TestParserDiffStates(t *testing.T) {
+	ps := testParseAll(
+		t, "tpdifs01", "--time=37", "-nn", "-xplay", "-t", "47", "effie")
+
+	testOpt := (*Option)(nil)
+	testStrArr := []string{}
+
+	psArgs := ps.Last()
+	assert.NotNil(t, psArgs)
+	assert.NotNil(t, psArgs.Value())
+	assert.IsType(t, testStrArr, psArgs.Value())
+	assert.Len(t, psArgs.Value(), 1)
+	assert.Equal(t, "effie", psArgs.Value().([]string)[0])
+
+	psT0 := ps.First()
+	assert.NotNil(t, psT0)
+	assert.NotNil(t, psT0.Value())
+	assert.Implements(t, testOpt, psT0.Value())
+	o := psT0.Value().(Option)
+	assert.EqualValues(t, 't', o.Opt())
+	assert.Equal(t, "37", o.Value())
+
+	psN0, _ := psT0.Next()
+	assert.NotNil(t, psN0)
+	assert.NotNil(t, psN0.Value())
+	assert.Implements(t, testOpt, psN0.Value())
+	o = psN0.Value().(Option)
+	assert.EqualValues(t, 'n', o.Opt())
+
+	psN1, _ := psN0.Next()
+	assert.NotNil(t, psN1)
+	assert.NotNil(t, psN1.Value())
+	assert.Implements(t, testOpt, psN1.Value())
+	o = psN1.Value().(Option)
+	assert.EqualValues(t, 'n', o.Opt())
+
+	psX0, _ := psN1.Next()
+	assert.NotNil(t, psX0)
+	assert.NotNil(t, psX0.Value())
+	assert.Implements(t, testOpt, psX0.Value())
+	o = psX0.Value().(Option)
+	assert.EqualValues(t, 'x', o.Opt())
+	assert.Equal(t, "play", o.Value())
+
+	psT1, _ := psX0.Next()
+	assert.NotNil(t, psT1)
+	assert.NotNil(t, psT1.Value())
+	assert.Implements(t, testOpt, psT1.Value())
+	o = psT1.Value().(Option)
+	assert.EqualValues(t, 't', o.Opt())
+	assert.Equal(t, "47", o.Value())
+}
+
+func newTestParser() Parser {
+	p := NewParser()
+	p.Opt('n', "name", NoArgument)
+	p.Opt('t', "time", RequiredArgument)
+	p.Opt('x', "xist", OptionalArgument)
+	p.Opt(0, "pulp", NoArgument)
+	return p
+}
+
+func testParseAll(t *testing.T, argv ...string) ParserState {
+	t.Logf("argv=%v\n", argv)
+	ps, _ := newTestParser().ParseAll(argv)
+	return ps
+}
+
+func testParse(t *testing.T, argv ...string) *parseTestResult {
+
+	t.Logf("argv=%v\n", argv)
+
+	r := &parseTestResult{}
+	c, _ := newTestParser().Parse(argv)
+	for i := range c {
+		t.Logf("i=%[1]T %[1]v\n", i)
+
+		switch ti := i.Value().(type) {
+		case Option:
+			switch ti.Opt() {
+			case 0:
+				if ti.LongName() == "pulp" {
+					r.pfnd = true
+				}
+			case 't':
+				r.tfnd = true
+				r.nsecs = ti.Value()
+			case 'n':
+				r.nfnd = true
+				r.nct++
+			case 'x':
+				r.xfnd = true
+				r.xist = ti.Value()
+			}
+		case error:
+			r.err = ti
+			return r
+		case []string:
+			r.name = ti[0]
+		default:
+			t.Fatalf("unknown chan val: %v", ti)
+		}
+	}
+	return r
+}
+
+func assertParseOk(t *testing.T, r *parseTestResult) {
+	assert.True(t, r.tfnd)
+	assert.True(t, r.nfnd)
+	assert.Equal(t, "37", r.nsecs)
+	assert.Equal(t, "effie", r.name)
+}
+
+func assertParseNoName(t *testing.T, r *parseTestResult) {
+	assert.True(t, r.tfnd)
+	assert.True(t, r.nfnd)
+	assert.Equal(t, "37", r.nsecs)
+	assert.Equal(t, "", r.name)
+}
+
+type parseTestResult struct {
+	argv  []string
+	argc  int
+	nfnd  bool
+	nsecs string
+	tfnd  bool
+	name  string
+	xfnd  bool
+	xist  string
+	pfnd  bool
+	err   error
+	nct   int
+}

--- a/log.go
+++ b/log.go
@@ -11,16 +11,16 @@ var (
 	debug = os.Getenv("GOTOPT_DEBUG") == "true"
 )
 
-// Debugln logs the arguments only if the logging level is DEBUG or higher.
-func Debugln(args ...interface{}) {
+// debugln logs the arguments only if the logging level is DEBUG or higher.
+func debugln(args ...interface{}) {
 	if !debug {
 		return
 	}
-	log.Println(args)
+	log.Println(args...)
 }
 
-// Debugf logs the arguments only if the logging level is DEBUG or higher.
-func Debugf(format string, args ...interface{}) {
+// debugf logs the arguments only if the logging level is DEBUG or higher.
+func debugf(format string, args ...interface{}) {
 	if !debug {
 		return
 	}

--- a/utils.go
+++ b/utils.go
@@ -25,7 +25,7 @@ func strncmp(str1, str2 string, num int) int {
 	lstr2 := len(str2)
 
 	for x := 0; x < num; x++ {
-		if (lstr1 < x && lstr2 >= x) || (lstr2 < x && lstr1 >= x) {
+		if x >= lstr1 || x >= lstr2 {
 			break
 		}
 		if str1[x] < str2[x] {


### PR DESCRIPTION
This patch adds the GotOpt Parser, a usability layer on top of the pure getopt functionality. The GotOpt Parser receives parsed options on a channel, a channel which can also receive any parsing errors, and will always send any remaining command line argument as a []string as the last element on the channel before it is closed. Please be aware if there are no non-option arguments to send, no string array is sent prior to the channel being closed. See the gotopt_test.go for an example of how to use the GotOpt Parser.
